### PR TITLE
Fix module group accessor for resolved artifacts

### DIFF
--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -32,7 +32,7 @@ class WitnessPlugin implements Plugin<Project> {
                     String hash  = parts.get(2)
 
                     ResolvedArtifact dependency = project.configurations.compile.resolvedConfiguration.resolvedArtifacts.find {
-                        return it.name.equals(name) && it.resolvedDependency.moduleGroup.equals(group)
+                        return it.name.equals(name) && it.moduleVersion.id.group.equals(group)
                     }
 
                     println "Verifying " + group + ":" + name


### PR DESCRIPTION
This fixes the following error when using gradle-witness with a project that requires Gradle 2.+:

```
No such property: resolvedDependency for class: org.gradle.api.internal.artifacts.DefaultResolvedArtifact
```
