### PR TITLE
Fix module group accessor for resolved artifacts in calculateChecksums

### DIFF
--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -53,7 +53,7 @@ class WitnessPlugin implements Plugin<Project> {
 
             project.configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
                 dep ->
-                    println "        '" + dep.resolvedDependency.moduleGroup+ ":" + dep.name + ":" + calculateSha256(dep.file) + "',"
+                    println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + calculateSha256(dep.file) + "',"
             }
 
             println "    ]"


### PR DESCRIPTION
This fixes an error with Gradle 2.+. Same fix as #3.
