### PR TITLE
Use full artifact version during verification

### DIFF
--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -21,24 +21,50 @@ class WitnessPlugin implements Plugin<Project> {
         return md.digest().collect {String.format "%02x", it}.join();
     }
 
+    static String stripFileExt(String fileName) {
+        int index = fileName.lastIndexOf(".")
+        if (index > 0) {
+            return fileName.substring(0, index)
+        }
+        return fileName
+    }
+
+    static String getFullVersion(ResolvedArtifact dep) {
+        String name = dep.name
+        String version = stripFileExt(dep.file.name)
+
+        if (name.equals(version)) {
+            return "0"
+        }
+
+        if (version.startsWith(name)) {
+            version = version.substring(name.length())
+            if (version.startsWith("-") && version.length() > 1) {
+                version = version.substring(1)
+            }
+        }
+        return version
+    }
+
     void apply(Project project) {
         project.extensions.create("dependencyVerification", WitnessPluginExtension)
         project.afterEvaluate {
             project.dependencyVerification.verify.each {
                 assertion ->
-                    List  parts  = assertion.tokenize(":")
-                    String group = parts.get(0)
-                    String name  = parts.get(1)
-                    String hash  = parts.get(2)
+                    List  parts    = assertion.tokenize(":")
+                    String group   = parts.get(0)
+                    String name    = parts.get(1)
+                    String version = parts.get(2)
+                    String hash    = parts.get(3)
 
                     ResolvedArtifact dependency = project.configurations.compile.resolvedConfiguration.resolvedArtifacts.find {
-                        return it.name.equals(name) && it.moduleVersion.id.group.equals(group)
+                        return it.name.equals(name) && it.moduleVersion.id.group.equals(group) && getFullVersion(it).equals(version)
                     }
 
-                    println "Verifying " + group + ":" + name
+                    println "Verifying " + group + ":" + name + ":" + version
 
                     if (dependency == null) {
-                        throw new InvalidUserDataException("No dependency for integrity assertion found: " + group + ":" + name)
+                        throw new InvalidUserDataException("No dependency for integrity assertion found: " + group + ":" + name + ":" + version)
                     }
 
                     if (!hash.equals(calculateSha256(dependency.file))) {
@@ -53,7 +79,7 @@ class WitnessPlugin implements Plugin<Project> {
 
             project.configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
                 dep ->
-                    println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + calculateSha256(dep.file) + "',"
+                    println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + getFullVersion(dep) + ":" + calculateSha256(dep.file) + "',"
             }
 
             println "    ]"


### PR DESCRIPTION
This solves a problem when transitive dependencies ends up with the
same name. Before this commit the following dependencies resulted in a
verifcation error:

Main dep:
- foo-1.0.0.jar

Transitive deps:
- foo-platform-1.0.0-linux.jar
- foo-platform-1.0.0-osx.jar
- foo-platform-1.0.0-windows.jar

In this case the dependencyVerification list had three entries
containing the name 'foo-platform' with different checksums. This
resulted in a conflict during verification.

This commit makes use of all the info that follows the name to find the
exact dependency, e.g. '1.0.0-linux' in this example.
