### PR TITLE
show calculated hash when comparison failed

### DIFF
--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -24,6 +24,7 @@ class WitnessPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.extensions.create("dependencyVerification", WitnessPluginExtension)
         project.afterEvaluate {
+            String failedChecksumsError = ""
             project.dependencyVerification.verify.each {
                 assertion ->
                     List  parts  = assertion.tokenize(":")
@@ -43,8 +44,11 @@ class WitnessPlugin implements Plugin<Project> {
 
                     String calculatedHash = calculateSha256(dependency.file)
                     if (!hash.equals(calculatedHash)) {
-                        throw new InvalidUserDataException("Checksum failed for " + assertion + "\ncalculated checksum: " + calculatedHash)
+                        failedChecksumsError += "Checksum failed for " + assertion + "\ncalculated checksum: " + calculatedHash + "\n\n"
                     }
+            }
+            if (failedChecksumsError != "") {
+                throw new InvalidUserDataException(failedChecksumsError)
             }
         }
 

--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -41,8 +41,9 @@ class WitnessPlugin implements Plugin<Project> {
                         throw new InvalidUserDataException("No dependency for integrity assertion found: " + group + ":" + name)
                     }
 
-                    if (!hash.equals(calculateSha256(dependency.file))) {
-                        throw new InvalidUserDataException("Checksum failed for " + assertion)
+                    String calculatedHash = calculateSha256(dependency.file)
+                    if (!hash.equals(calculatedHash)) {
+                        throw new InvalidUserDataException("Checksum failed for " + assertion + "\ncalculated checksum: " + calculatedHash)
                     }
             }
         }


### PR DESCRIPTION
This shows the calculated hash in the error message. It should make it easier to update dependencies since you dont have to run `gradle -q calculateChecksums` to calculate the new checksum.
