### PR TITLE
add task 'printDependencyLocations'

### DIFF
--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -59,6 +59,18 @@ class WitnessPlugin implements Plugin<Project> {
             println "    ]"
             println "}"
         }
+
+        project.task('printDependencyLocations') << {
+            println "Dependency Locations: ["
+        
+            project.configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
+                dep ->
+                    println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + dep.file + "',"
+            }
+        
+            println "    ]"
+         }
+
     }
 }
 


### PR DESCRIPTION
This code adds a task "Print Dependency Locations" which just prints the locations of each dependency on the filesystem. I have found this useful to have when wanting to check dependencies by hand.
