### PR TITLE
Use testRuntime dependencies instead of compile

### DIFF
--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -31,7 +31,7 @@ class WitnessPlugin implements Plugin<Project> {
                     String name  = parts.get(1)
                     String hash  = parts.get(2)
 
-                    ResolvedArtifact dependency = project.configurations.compile.resolvedConfiguration.resolvedArtifacts.find {
+                    ResolvedArtifact dependency = project.configurations.testRuntime.resolvedConfiguration.resolvedArtifacts.find {
                         return it.name.equals(name) && it.moduleVersion.id.group.equals(group)
                     }
 
@@ -45,13 +45,15 @@ class WitnessPlugin implements Plugin<Project> {
                         throw new InvalidUserDataException("Checksum failed for " + assertion)
                     }
             }
+
         }
+
 
         project.task('calculateChecksums') << {
             println "dependencyVerification {"
             println "    verify = ["
 
-            project.configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
+            project.configurations.testRuntime.resolvedConfiguration.resolvedArtifacts.each {
                 dep ->
                     println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + calculateSha256(dep.file) + "',"
             }


### PR DESCRIPTION
Get dependencies from testRuntime instead of compile. Based on gradle [dependency configurations](https://docs.gradle.org/current/userguide/artifact_dependencies_tutorial.html#configurations). 