### PR TITLE
Dont't throw an exception when depency is not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: groovy
+
+script:
+- gradle build
+- sha256sum build/libs/gradle-witness.jar

--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -38,7 +38,7 @@ class WitnessPlugin implements Plugin<Project> {
                     println "Verifying " + group + ":" + name
 
                     if (dependency == null) {
-                        throw new InvalidUserDataException("No dependency for integrity assertion found: " + group + ":" + name)
+                        return
                     }
 
                     if (!hash.equals(calculateSha256(dependency.file))) {


### PR DESCRIPTION
If a dependency is not used in a build flavor (e.g. GCM in foss-flavor),
an exception is thrown. The only option without modifing the code is
to remove the assertions for those libaries.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>