### PR TITLE
Log 'Verifying' messages at INFO level

### DIFF
--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -35,7 +35,7 @@ class WitnessPlugin implements Plugin<Project> {
                         return it.name.equals(name) && it.moduleVersion.id.group.equals(group)
                     }
 
-                    println "Verifying " + group + ":" + name
+                    project.logger.info("Verifying " + group + ":" + name)
 
                     if (dependency == null) {
                         throw new InvalidUserDataException("No dependency for integrity assertion found: " + group + ":" + name)


### PR DESCRIPTION
Problem: WitnessPlugin used `println` to print "Verifying ..." messages
forcing the output to show up at the console under all conditions.

Solution: Print the same messages using `project.logger` at INFO level,
such that "Verifying ..." messages are not printed at all by default,
but are printed if `-i/--info` is provided at the command line.