### PR TITLE
Replace deprecated leftShift(Closure) method

### DIFF
--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -47,17 +47,19 @@ class WitnessPlugin implements Plugin<Project> {
             }
         }
 
-        project.task('calculateChecksums') << {
-            println "dependencyVerification {"
-            println "    verify = ["
+        project.task('calculateChecksums') {
+            doLast {
+                println "dependencyVerification {"
+                println "    verify = ["
 
-            project.configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
-                dep ->
-                    println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + calculateSha256(dep.file) + "',"
+                project.configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
+                    dep ->
+                        println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + calculateSha256(dep.file) + "',"
+                }
+
+                println "    ]"
+                println "}"
             }
-
-            println "    ]"
-            println "}"
         }
     }
 }


### PR DESCRIPTION
Issue: The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0.

Fix: Use Task.doLast(Action) instead.

Resolves: https://github.com/signalapp/gradle-witness/issues/22