### PR TITLE
Removed deprecated LeftShift to support gradle 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Gradle Witness
+# Gradle Witness - Gradle 5 compatible version
 
-A gradle plugin that enables static verification for remote dependencies.
+A gradle plugin that enables static verification for remote dependencies. This fork of gradle-witness is compatible with gradle 4 and 5.
 
 Build systems like gradle and maven allow one to specify dependencies for versioned artifacts. An
 Android project might list dependencies like this:

--- a/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
+++ b/src/main/groovy/org/whispersystems/witness/WitnessPlugin.groovy
@@ -47,17 +47,19 @@ class WitnessPlugin implements Plugin<Project> {
             }
         }
 
-        project.task('calculateChecksums') << {
-            println "dependencyVerification {"
-            println "    verify = ["
+        project.task('calculateChecksums') {
+            doLast{
+                println "dependencyVerification {"
+                println "    verify = ["
 
-            project.configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
-                dep ->
-                    println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + calculateSha256(dep.file) + "',"
+                project.configurations.compile.resolvedConfiguration.resolvedArtifacts.each {
+                    dep ->
+                        println "        '" + dep.moduleVersion.id.group+ ":" + dep.name + ":" + calculateSha256(dep.file) + "',"
+                }
+
+                println "    ]"
+                println "}"
             }
-
-            println "    ]"
-            println "}"
         }
     }
 }


### PR DESCRIPTION
Hello moxie0,

I have removed the deprecated LeftShift in calculateChecksums task to make gradle-witness compatible with gradle >= 5.
It's just a syntactical change and shouldn't have any side effects.

Kind regards,
Ulrich Viefhaus